### PR TITLE
added missing include

### DIFF
--- a/include/numpycpp/np_array.h
+++ b/include/numpycpp/np_array.h
@@ -6,6 +6,7 @@
 #include "np_base_iterator.h"
 
 #include <filesystem>
+#include <cstring>
 #include <fstream>
 #include <regex>
 


### PR DESCRIPTION
clang works fine, but gcc started throwing.

```console
$ rm -r build; cmake -DCMAKE_C_COMPILER=(which gcc-12) -DCMAKE_CXX_COMPILER=(which g++-12) -S . -B build; cmake --build build                                                           ◦◦◦ ◦ master
rm: build: No such file or directory
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- The C compiler identification is GNU 12.3.0
-- The CXX compiler identification is GNU 12.3.0
-- Checking whether C compiler has -isysroot
-- Checking whether C compiler has -isysroot - yes
-- Checking whether C compiler supports OSX deployment target flag
-- Checking whether C compiler supports OSX deployment target flag - yes
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/local/bin/gcc-12 - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Checking whether CXX compiler has -isysroot
-- Checking whether CXX compiler has -isysroot - yes
-- Checking whether CXX compiler supports OSX deployment target flag
-- Checking whether CXX compiler supports OSX deployment target flag - yes
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/local/bin/g++-12 - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done (2.9s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/james/Development/NumPyCpp/build
[ 14%] Building CXX object src/CMakeFiles/numpycpp.dir/np_array.cpp.o
In file included from /Users/james/Development/NumPyCpp/src/np_array.cpp:1:
/Users/james/Development/NumPyCpp/include/numpycpp/np_array.h: In static member function 'static np::array np::array::load(Handle&)':
/Users/james/Development/NumPyCpp/include/numpycpp/np_array.h:77:17: error: 'strcmp' is not a member of 'std'
   77 |         if(std::strcmp(magic, "\x93NUMPY") != 0)
      |                 ^~~~~~
/Users/james/Development/NumPyCpp/src/np_array.cpp: In constructor 'np::array::array(np::descr_t, np::shape_t, bool)':
/Users/james/Development/NumPyCpp/src/np_array.cpp:48:14: error: 'memset' is not a member of 'std'; did you mean 'wmemset'?
   48 |         std::memset(_data, 0, size);
      |              ^~~~~~
      |              wmemset
/Users/james/Development/NumPyCpp/src/np_array.cpp: In member function 'np::array& np::array::operator=(const np::array&)':
/Users/james/Development/NumPyCpp/src/np_array.cpp:77:14: error: 'memcpy' is not a member of 'std'; did you mean 'wmemcpy'?
   77 |         std::memcpy(_data, c._data, size);
      |              ^~~~~~
      |              wmemcpy
/Users/james/Development/NumPyCpp/src/np_array.cpp: In member function 'void np::file_io::read(void*, std::size_t)':
/Users/james/Development/NumPyCpp/src/np_array.cpp:579:26: error: 'strerror' is not a member of 'std'; did you mean 'perror'?
  579 |         throw error(std::strerror(errno));
      |                          ^~~~~~~~
      |                          perror
/Users/james/Development/NumPyCpp/src/np_array.cpp: In member function 'void np::file_io::write(const void*, std::size_t)':
/Users/james/Development/NumPyCpp/src/np_array.cpp:593:26: error: 'strerror' is not a member of 'std'; did you mean 'perror'?
  593 |         throw error(std::strerror(errno));
      |                          ^~~~~~~~
      |                          perror
gmake[2]: *** [src/CMakeFiles/numpycpp.dir/build.make:76: src/CMakeFiles/numpycpp.dir/np_array.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:116: src/CMakeFiles/numpycpp.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2
```